### PR TITLE
Changed qtmodern.windows.ModernWindow's init() to preserve the title of the widget it wraps. Added short test script to demonstrate this functionality

### DIFF
--- a/qtmodern/testpatch.py
+++ b/qtmodern/testpatch.py
@@ -1,0 +1,30 @@
+"""
+Test patch for qtmodern
+
+If a widget to be wrapped by a ModernWindow object has a non-empty title.
+Then the ModernWindow widget will preserve this title after wrapping.
+
+Maxwell Grady
+September 22, 2017
+"""
+
+import sys
+from PyQt5 import QtWidgets
+from qtmodern.styles import dark
+from qtmodern.windows import ModernWindow
+
+def main():
+    app = QtWidgets.QApplication([])
+    dark(app)
+
+    # create widget to be wrapped by ModernWindow
+    # set widget title before wrapping
+    widget = QtWidgets.QWidget()
+    widget.setWindowTitle("QWidgetTitle")
+
+    modwin = ModernWindow(widget)
+    modwin.show()
+    sys.exit(app.exec_())
+
+if __name__ == '__main__':
+    main()

--- a/qtmodern/windows.py
+++ b/qtmodern/windows.py
@@ -59,6 +59,13 @@ class ModernWindow(QWidget):
         contentLayout.setContentsMargins(0, 0, 0, 0)
         contentLayout.addWidget(w)
 
+        # w's title will get lost after being wrapped by ModernWindow
+        # set the ModernWindow title to w's window title if it exists.
+        # to prevent being overwritten with default value,
+        # this needs to happen after the call to setupUI()
+        if str(w.windowTitle()) != '':
+            self.setTitle(str(w.windowTitle()))
+
         self.windowContent.setLayout(contentLayout)
 
     def setupUi(self):


### PR DESCRIPTION
Added file testpatch.py to demonstrate the intended behavior

Edited windows.py to include the change to ModernWindow's init() method