### PR TITLE
Clean up parent window on child delete/close

### DIFF
--- a/qtmodern/windows.py
+++ b/qtmodern/windows.py
@@ -69,6 +69,10 @@ class ModernWindow(QWidget):
 
         self.installEventFilter(self)
 
+        # Adding attribute to clean up the parent window when the child is closed
+        self._w.setAttribute(Qt.WA_DeleteOnClose, True)
+        self._w.destroyed.connect(self.__child_was_closed)
+
     def setupUi(self):
         # create title bar, content
         self.vboxWindow = QVBoxLayout(self)
@@ -138,8 +142,14 @@ class ModernWindow(QWidget):
         # automatically connect slots
         QMetaObject.connectSlotsByName(self)
 
+    def __child_was_closed(self):
+        self._w = None  # The child was deleted, remove the reference to it and close the parent window
+        self.close()
+
     def eventFilter(self, source, event):
         if event.type() == QEvent.Close:
+            if not self._w:
+                return True
             return self._w.close()
 
         return QWidget.eventFilter(self, source, event)


### PR DESCRIPTION
**Summery**
Fixes https://github.com/gmarull/qtmodern/issues/19

**Purpose of change**
If a child calls `self.close` it will not send the event to the parent. The outcome is that the child (that `self.close` was called on) is gone but a frame (modern window) remains.

**Describe the solution**
By setting the DeleteOnClose attribute on the child we can listen for when it is destroyed. When it is destroyed we can then clean up and close the modern window.

**Potensial problems**
Someone could rely on that `Qt.WA_DeleteOnClose` is not set in their application. But I do not think that is common, letting people do `self.setAttribute(Qt.WA_DeleteOnClose, False)` after init in that rare case is fine I think.

**Describe alternatives you've considered**
Modifying the example to use `QApplication.instance().quit()` in the `closeEvent` as well as maybe mention it in the readme.md, very "none intrusive" but would always have to be done.
