### PR TITLE
Expose a reference to the ModernWindow on the child

### DIFF
--- a/examples/mainwindow.py
+++ b/examples/mainwindow.py
@@ -28,8 +28,14 @@ class MainWindow(QMainWindow):
         qtmodern.styles.dark(QApplication.instance())
 
     @Slot()
-    def on_pushButton_clicked(self):
+    def on_pushButton_clicked(self):  # The ModernWindow automatically connects the slot based on name
         self.close()
+
+    @Slot()
+    def on_pushButton_2_clicked(self):
+        # The ModernWindow have control over the window title, therefore calling self.setWindowTitle will do nothing.
+        # We need to set the window title directly on the ModernWindow
+        self.ModernWindow.setWindowTitle("Changed window title")
 
     @Slot()
     def closeEvent(self, event):

--- a/examples/mainwindow.ui
+++ b/examples/mainwindow.ui
@@ -132,14 +132,14 @@
        <item>
         <widget class="QPushButton" name="pushButton">
          <property name="text">
-          <string>PushButton</string>
+          <string>Exit</string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QPushButton" name="pushButton_2">
          <property name="text">
-          <string>PushButton</string>
+          <string>Change Title</string>
          </property>
          <property name="checkable">
           <bool>true</bool>
@@ -185,8 +185,8 @@
            <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.SF NS Text'; font-size:13pt;&quot;&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.SF NS Text'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;test&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>
@@ -403,7 +403,7 @@ p, li { white-space: pre-wrap; }
      <x>0</x>
      <y>0</y>
      <width>670</width>
-     <height>21</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuTest">

--- a/qtmodern/windows.py
+++ b/qtmodern/windows.py
@@ -56,6 +56,7 @@ class ModernWindow(QWidget):
         QWidget.__init__(self, parent)
 
         self._w = w
+        self._w.ModernWindow = self
         self.setupUi()
 
         contentLayout = QHBoxLayout()


### PR DESCRIPTION
**Purpose of change**
If I in my MainWindow change the title (say on a button press) with `self.setWindowTitle` nothing will happen because it isn't my MainWindow that have control of the title, ModernWindow does.

**Describe the solution**
Expose a reference to the ModernWindow on `self._w`. This will give users a lot more control, not only for changing title.

**Describe alternatives you've considered**
We could in the `__init__` of `ModernWindow` add `self._w.setWindowTitle = self.setWindowTitle`, but this would need to be done for all attributes and thus doesn't scale. Better to let the user edit the ModernWindow instance.

**Additional**
Added some explanations in the example app to clarify some "whys" and "hows".
