### PR TITLE
Set ModernWindow to set the event state equal to the child state

### DIFF
--- a/qtmodern/windows.py
+++ b/qtmodern/windows.py
@@ -146,8 +146,10 @@ class ModernWindow(QWidget):
 
     def closeEvent(self, event):
         if not self._w:
-            return True
-        event.setAccepted(self._w.close())
+            event.accept()
+        else:
+            self._w.close()
+            event.setAccepted(self._w.isHidden())
 
     def setWindowTitle(self, title):
         """ Set window title.

--- a/qtmodern/windows.py
+++ b/qtmodern/windows.py
@@ -67,8 +67,6 @@ class ModernWindow(QWidget):
         self.setWindowTitle(w.windowTitle())
         self.setGeometry(w.geometry())
 
-        self.installEventFilter(self)
-
         # Adding attribute to clean up the parent window when the child is closed
         self._w.setAttribute(Qt.WA_DeleteOnClose, True)
         self._w.destroyed.connect(self.__child_was_closed)
@@ -146,13 +144,10 @@ class ModernWindow(QWidget):
         self._w = None  # The child was deleted, remove the reference to it and close the parent window
         self.close()
 
-    def eventFilter(self, source, event):
-        if event.type() == QEvent.Close:
-            if not self._w:
-                return True
-            return self._w.close()
-
-        return QWidget.eventFilter(self, source, event)
+    def closeEvent(self, event):
+        if not self._w:
+            return True
+        event.setAccepted(self._w.close())
 
     def setWindowTitle(self, title):
         """ Set window title.


### PR DESCRIPTION
**Purpose of change**
If you click on the (x) button to close a window ModernWindow and the Child get different closeEvent's. This means that even of I `.ignore()` the event in the Child. The ModernWindow doesn't know this and closes anyway. (This can be observed by running the mainwindow.py and pressing the (x) button and taking "No" in the dialog - it closes anyway).

**Describe the solution**
Set the ModernWindow event to be accepted by the return value of the child's `.close()`

**Potensial Problems**
I am not sure what the need for the `eventFilter` as opposed to `closeEvent`, I changed ModernWindow to only use closeEvent for simplicity sake.
