### PR TITLE
#26 QScrollArea inconsistent background color

### DIFF
--- a/qtmodern/resources/style.qss
+++ b/qtmodern/resources/style.qss
@@ -119,7 +119,7 @@ QScrollArea {
   border-style: none;
 }
 
-QScrollArea #scrollAreaWidgetContents {
+QScrollArea QWidget {
   background-color: palette(alternate-base);
 }
 

--- a/qtmodern/resources/style.qss
+++ b/qtmodern/resources/style.qss
@@ -119,7 +119,7 @@ QScrollArea {
   border-style: none;
 }
 
-QScrollArea QWidget {
+QScrollArea > QWidget > QWidget {
   background-color: palette(alternate-base);
 }
 


### PR DESCRIPTION
Fixes https://github.com/gmarull/qtmodern/issues/26

This change uses a descendant reference and will now color all scrollAreaWidgetContents regardless of name.

Changed from referring to `QScrollArea`s child using the _name_ (`#scrollAreaWidgetContents`) it can only be applied to the first created `QScrollArea`.


