### PR TITLE
Using the midlight color for scrollbars

### DIFF
--- a/qtmodern/resources/style.qss
+++ b/qtmodern/resources/style.qss
@@ -63,7 +63,7 @@ QScrollBar::handle:vertical {
 }
 
 QScrollBar::handle:vertical:hover, QScrollBar::handle:horizontal:hover, QScrollBar::handle:vertical:pressed, QScrollBar::handle:horizontal:pressed {
-  background-color:palette(highlight);
+  background-color:palette(midlight);
 }
 
 QScrollBar::add-line:vertical {


### PR DESCRIPTION
_This PR is purely personal opinion and feel free to close and disregard if you like the current behavior._

I like the nice blue color as a highlight color but I think that it is a bit too much on the scrollbar, I propouse changing that to a more neutral color.

## Before
![after](https://user-images.githubusercontent.com/5273682/68590938-f4ac7a00-048f-11ea-93a3-24ae1207c88b.gif)![highlight-light](https://user-images.githubusercontent.com/5273682/68590972-0130d280-0490-11ea-8763-af4e422430ce.gif)

## After
![midlight](https://user-images.githubusercontent.com/5273682/68591008-0ee65800-0490-11ea-9b6c-50a5020aa1e3.gif)![midlight-light](https://user-images.githubusercontent.com/5273682/68591007-0ee65800-0490-11ea-9965-563bc3d477c6.gif)
