### PR TITLE
Option to create ModernWindow with hidden window buttons

### DIFF
--- a/qtmodern/resources/frameless.qss
+++ b/qtmodern/resources/frameless.qss
@@ -55,3 +55,7 @@
 #btnClose::pressed {
   background-color: hsv(0, 182, 152);
 }
+
+#btnClose::disabled, #btnRestore::disabled, #btnMaximize::disabled, #btnMinimize::disabled {
+  background-color: palette(midlight);
+}

--- a/qtmodern/windows.py
+++ b/qtmodern/windows.py
@@ -203,7 +203,7 @@ class ModernWindow(QWidget):
         else:
             for b in allButtons:
                 b.setVisible(False)
-            self.lblTitle.setContentsMargins(0, 5, 0, 0)
+            self.lblTitle.setContentsMargins(0, 2, 0, 0)
 
     def setWindowFlag(self, Qt_WindowType, on=True):
         buttonHints = [Qt.WindowCloseButtonHint, Qt.WindowMinimizeButtonHint, Qt.WindowMaximizeButtonHint]

--- a/qtmodern/windows.py
+++ b/qtmodern/windows.py
@@ -168,7 +168,7 @@ class ModernWindow(QWidget):
         super(ModernWindow, self).setWindowTitle(title)
         self.lblTitle.setText(title)
 
-    def _setWindowButtonState(self, button: QToolButton, state: bool):
+    def _setWindowButtonState(self, button, state):
         button.setVisible(state)
         if False in [x.isHidden() for x in [self.btnClose, self.btnMinimize, self.btnMaximize, self.btnRestore]]:
             self.lblTitle.setContentsMargins(0, 0, 0, 0)

--- a/qtmodern/windows.py
+++ b/qtmodern/windows.py
@@ -176,19 +176,33 @@ class ModernWindow(QWidget):
         }
         button = btns.get(hint)
 
+        maximized = bool(self.windowState() & Qt.WindowMaximized)
+
         if button == self.btnMaximize:  # special rules for max/restore
-            if bool(self.windowState() & Qt.WindowMaximized):
+            self.btnRestore.setEnabled(state)
+            self.btnMaximize.setEnabled(state)
+
+            if maximized:
                 self.btnRestore.setVisible(state)
                 self.btnMaximize.setVisible(False)
             else:
-                self.btnRestore.setVisible(False)
                 self.btnMaximize.setVisible(state)
-            return
+                self.btnRestore.setVisible(False)
+        else:
+            button.setEnabled(state)
 
-        button.setVisible(state)
-        if False in [x.isHidden() for x in [self.btnClose, self.btnMinimize, self.btnMaximize, self.btnRestore]]:
+        allButtons = [self.btnClose, self.btnMinimize, self.btnMaximize, self.btnRestore]
+        if True in [b.isEnabled() for b in allButtons]:
+            for b in allButtons:
+                b.setVisible(True)
+            if maximized:
+                self.btnMaximize.setVisible(False)
+            else:
+                self.btnRestore.setVisible(False)
             self.lblTitle.setContentsMargins(0, 0, 0, 0)
         else:
+            for b in allButtons:
+                b.setVisible(False)
             self.lblTitle.setContentsMargins(0, 5, 0, 0)
 
     def setWindowFlag(self, Qt_WindowType, on=True):
@@ -212,17 +226,21 @@ class ModernWindow(QWidget):
 
     @Slot()
     def on_btnRestore_clicked(self):
-        if self.btnMaximize.isVisible() or self.btnRestore.isVisible():
+        if self.btnMaximize.isEnabled() or self.btnRestore.isEnabled():
             self.btnRestore.setVisible(False)
+            self.btnRestore.setEnabled(False)
             self.btnMaximize.setVisible(True)
+            self.btnMaximize.setEnabled(True)
 
         self.setWindowState(Qt.WindowNoState)
 
     @Slot()
     def on_btnMaximize_clicked(self):
-        if self.btnMaximize.isVisible() or self.btnRestore.isVisible():
+        if self.btnMaximize.isEnabled() or self.btnRestore.isEnabled():
             self.btnRestore.setVisible(True)
+            self.btnRestore.setEnabled(True)
             self.btnMaximize.setVisible(False)
+            self.btnMaximize.setEnabled(False)
 
         self.setWindowState(Qt.WindowMaximized)
 

--- a/qtmodern/windows.py
+++ b/qtmodern/windows.py
@@ -52,8 +52,9 @@ class ModernWindow(QWidget):
             parent (QWidget, optional): Parent widget.
     """
 
-    def __init__(self, w, parent=None):
+    def __init__(self, w, parent=None, hideWindowButtons=False):
         QWidget.__init__(self, parent)
+        self.hideWindowButtons = hideWindowButtons
 
         self._w = w
         self.setupUi()
@@ -134,6 +135,13 @@ class ModernWindow(QWidget):
             self.hboxTitle.addWidget(self.btnMaximize)
             self.hboxTitle.addWidget(self.btnClose)
 
+        if self.hideWindowButtons:
+            self.hboxTitle.setContentsMargins(0, 5, 0, 0)
+            self.btnClose.hide()
+            self.btnMinimize.hide()
+            self.btnRestore.hide()
+            self.btnMaximize.hide()
+
         # set window flags
         self.setWindowFlags(
                 Qt.Window | Qt.FramelessWindowHint | Qt.WindowSystemMenuHint)
@@ -175,15 +183,17 @@ class ModernWindow(QWidget):
 
     @Slot()
     def on_btnRestore_clicked(self):
-        self.btnRestore.setVisible(False)
-        self.btnMaximize.setVisible(True)
+        if not self.hideWindowButtons:
+            self.btnRestore.setVisible(False)
+            self.btnMaximize.setVisible(True)
 
         self.setWindowState(Qt.WindowNoState)
 
     @Slot()
     def on_btnMaximize_clicked(self):
-        self.btnRestore.setVisible(True)
-        self.btnMaximize.setVisible(False)
+        if not self.hideWindowButtons:
+            self.btnRestore.setVisible(True)
+            self.btnMaximize.setVisible(False)
 
         self.setWindowState(Qt.WindowMaximized)
 


### PR DESCRIPTION
Added option to create ModernWindow with hidden window buttons.
This is useful, if you want to create for example an update MainWindow, that should not be cancelled by the user.