### PR TITLE
added ModernDialog and ModernMessageBox

### DIFF
--- a/qtmodern/windows.py
+++ b/qtmodern/windows.py
@@ -1,6 +1,5 @@
 from qtpy.QtCore import Qt, QMetaObject, Signal, Slot
-from qtpy.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QToolButton,
-                            QLabel, QSizePolicy)
+from qtpy.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QToolButton, QLabel, QSizePolicy, QDialog, QMessageBox)
 from ._utils import QT_VERSION, PLATFORM, resource_path
 
 
@@ -41,6 +40,67 @@ class WindowDragger(QWidget):
         self.doubleClicked.emit()
 
 
+class TitleBar(WindowDragger):
+    """ Window titlebar.
+        Args:
+            window (QWidget): The window to attach to.
+    """
+    def __init__(self, window):
+        super().__init__(window, window.windowFrame)
+        self.window = window
+        self.setupUi()
+
+    def setupUi(self):
+        self.setObjectName('titleBar')
+        self.setSizePolicy(QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed))
+
+        self.window.hboxTitle = QHBoxLayout(self)
+        self.window.hboxTitle.setContentsMargins(0, 0, 0, 0)
+        self.window.hboxTitle.setSpacing(0)
+
+        self.window.lblTitle = QLabel('Title')
+        self.window.lblTitle.setObjectName('lblTitle')
+        self.window.lblTitle.setAlignment(Qt.AlignCenter)
+
+        spButtons = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        self.window.btnMinimize = QToolButton(self)
+        self.window.btnMinimize.setObjectName('btnMinimize')
+        self.window.btnMinimize.setSizePolicy(spButtons)
+
+        self.window.btnRestore = QToolButton(self)
+        self.window.btnRestore.setObjectName('btnRestore')
+        self.window.btnRestore.setSizePolicy(spButtons)
+
+        self.window.btnMaximize = QToolButton(self)
+        self.window.btnMaximize.setObjectName('btnMaximize')
+        self.window.btnMaximize.setSizePolicy(spButtons)
+
+        self.window.btnClose = QToolButton(self)
+        self.window.btnClose.setObjectName('btnClose')
+        self.window.btnClose.setSizePolicy(spButtons)
+
+        self.window.vboxFrame.addWidget(self)
+
+        self.window.windowContent = QWidget(self.window.windowFrame)
+        self.window.vboxFrame.addWidget(self.window.windowContent)
+
+        self.window.vboxWindow.addWidget(self.window.windowFrame)
+
+        if PLATFORM == "Darwin":
+            self.window.hboxTitle.addWidget(self.window.btnClose)
+            self.window.hboxTitle.addWidget(self.window.btnMinimize)
+            self.window.hboxTitle.addWidget(self.window.btnRestore)
+            self.window.hboxTitle.addWidget(self.window.btnMaximize)
+            self.window.hboxTitle.addWidget(self.window.lblTitle)
+        else:
+            self.window.hboxTitle.addWidget(self.window.lblTitle)
+            self.window.hboxTitle.addWidget(self.window.btnMinimize)
+            self.window.hboxTitle.addWidget(self.window.btnRestore)
+            self.window.hboxTitle.addWidget(self.window.btnMaximize)
+            self.window.hboxTitle.addWidget(self.window.btnClose)
+
+
 class ModernWindow(QWidget):
     """ Modern window.
 
@@ -79,56 +139,7 @@ class ModernWindow(QWidget):
         self.vboxFrame = QVBoxLayout(self.windowFrame)
         self.vboxFrame.setContentsMargins(0, 0, 0, 0)
 
-        self.titleBar = WindowDragger(self, self.windowFrame)
-        self.titleBar.setObjectName('titleBar')
-        self.titleBar.setSizePolicy(QSizePolicy(QSizePolicy.Preferred,
-                                                QSizePolicy.Fixed))
-
-        self.hboxTitle = QHBoxLayout(self.titleBar)
-        self.hboxTitle.setContentsMargins(0, 0, 0, 0)
-        self.hboxTitle.setSpacing(0)
-
-        self.lblTitle = QLabel('Title')
-        self.lblTitle.setObjectName('lblTitle')
-        self.lblTitle.setAlignment(Qt.AlignCenter)
-
-        spButtons = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
-
-        self.btnMinimize = QToolButton(self.titleBar)
-        self.btnMinimize.setObjectName('btnMinimize')
-        self.btnMinimize.setSizePolicy(spButtons)
-
-        self.btnRestore = QToolButton(self.titleBar)
-        self.btnRestore.setObjectName('btnRestore')
-        self.btnRestore.setSizePolicy(spButtons)
-
-        self.btnMaximize = QToolButton(self.titleBar)
-        self.btnMaximize.setObjectName('btnMaximize')
-        self.btnMaximize.setSizePolicy(spButtons)
-
-        self.btnClose = QToolButton(self.titleBar)
-        self.btnClose.setObjectName('btnClose')
-        self.btnClose.setSizePolicy(spButtons)
-
-        self.vboxFrame.addWidget(self.titleBar)
-
-        self.windowContent = QWidget(self.windowFrame)
-        self.vboxFrame.addWidget(self.windowContent)
-
-        self.vboxWindow.addWidget(self.windowFrame)
-
-        if PLATFORM == "Darwin":
-            self.hboxTitle.addWidget(self.btnClose)
-            self.hboxTitle.addWidget(self.btnMinimize)
-            self.hboxTitle.addWidget(self.btnRestore)
-            self.hboxTitle.addWidget(self.btnMaximize)
-            self.hboxTitle.addWidget(self.lblTitle)
-        else:
-            self.hboxTitle.addWidget(self.lblTitle)
-            self.hboxTitle.addWidget(self.btnMinimize)
-            self.hboxTitle.addWidget(self.btnRestore)
-            self.hboxTitle.addWidget(self.btnMaximize)
-            self.hboxTitle.addWidget(self.btnClose)
+        self.titleBar = TitleBar(self)
 
         # set window flags
         self.setWindowFlags(Qt.Window | Qt.FramelessWindowHint | Qt.WindowSystemMenuHint | Qt.WindowCloseButtonHint |
@@ -251,3 +262,179 @@ class ModernWindow(QWidget):
             self.on_btnMaximize_clicked()
         else:
             self.on_btnRestore_clicked()
+
+
+class ModernDialog(QDialog):
+    """ Modern window.
+
+        Args:
+            w (QDialog): Main widget.
+            parent (QWidget, optional): Parent widget.
+    """
+
+    def __init__(self, parent=None):
+        QDialog.__init__(self, parent)
+        self.setupUi()
+
+    def setupUi(self):
+        # create title bar, content
+        self.vboxWindow = QVBoxLayout(self)
+        self.vboxWindow.setContentsMargins(0, 0, 0, 0)
+
+        self.windowFrame = QWidget(self)
+        self.windowFrame.setObjectName('windowFrame')
+
+        self.vboxFrame = QVBoxLayout(self.windowFrame)
+        self.vboxFrame.setContentsMargins(0, 0, 0, 0)
+
+        self.titleBar = TitleBar(self)
+
+        # set window flags
+        self.setWindowFlags(Qt.Window | Qt.FramelessWindowHint | Qt.WindowSystemMenuHint | Qt.WindowCloseButtonHint |
+                            Qt.WindowMinimizeButtonHint | Qt.WindowMaximizeButtonHint)
+
+        if QT_VERSION >= (5,):
+            self.setAttribute(Qt.WA_TranslucentBackground)
+
+        # set stylesheet
+        with open(_FL_STYLESHEET) as stylesheet:
+            self.setStyleSheet(stylesheet.read())
+
+        # automatically connect slots
+        QMetaObject.connectSlotsByName(self)
+
+    def __child_was_closed(self):
+        self._w = None  # The child was deleted, remove the reference to it and close the parent window
+        self.close()
+
+    def closeEvent(self, event):
+        if not self._w:
+            event.accept()
+        else:
+            self._w.close()
+            event.setAccepted(self._w.isHidden())
+
+    def setWindowTitle(self, title):
+        """ Set window title.
+
+            Args:
+                title (str): Title.
+        """
+
+        super(ModernDialog, self).setWindowTitle(title)
+        self.lblTitle.setText(title)
+
+    def _setWindowButtonState(self, hint, state):
+        btns = {
+            Qt.WindowCloseButtonHint: self.btnClose,
+            Qt.WindowMinimizeButtonHint: self.btnMinimize,
+            Qt.WindowMaximizeButtonHint: self.btnMaximize
+        }
+        button = btns.get(hint)
+
+        maximized = bool(self.windowState() & Qt.WindowMaximized)
+
+        if button == self.btnMaximize:  # special rules for max/restore
+            self.btnRestore.setEnabled(state)
+            self.btnMaximize.setEnabled(state)
+
+            if maximized:
+                self.btnRestore.setVisible(state)
+                self.btnMaximize.setVisible(False)
+            else:
+                self.btnMaximize.setVisible(state)
+                self.btnRestore.setVisible(False)
+        else:
+            button.setEnabled(state)
+
+        allButtons = [self.btnClose, self.btnMinimize, self.btnMaximize, self.btnRestore]
+        if True in [b.isEnabled() for b in allButtons]:
+            for b in allButtons:
+                b.setVisible(True)
+            if maximized:
+                self.btnMaximize.setVisible(False)
+            else:
+                self.btnRestore.setVisible(False)
+            self.lblTitle.setContentsMargins(0, 0, 0, 0)
+        else:
+            for b in allButtons:
+                b.setVisible(False)
+            self.lblTitle.setContentsMargins(0, 2, 0, 0)
+
+    def setWindowFlag(self, Qt_WindowType, on=True):
+        buttonHints = [Qt.WindowCloseButtonHint, Qt.WindowMinimizeButtonHint, Qt.WindowMaximizeButtonHint]
+
+        if Qt_WindowType in buttonHints:
+            self._setWindowButtonState(Qt_WindowType, on)
+        else:
+            QWidget.setWindowFlag(self, Qt_WindowType, on)
+
+    def setWindowFlags(self, Qt_WindowFlags):
+        buttonHints = [Qt.WindowCloseButtonHint, Qt.WindowMinimizeButtonHint, Qt.WindowMaximizeButtonHint]
+        for hint in buttonHints:
+            self._setWindowButtonState(hint, bool(Qt_WindowFlags & hint))
+
+        QWidget.setWindowFlags(self, Qt_WindowFlags)
+
+    @Slot()
+    def on_btnMinimize_clicked(self):
+        self.setWindowState(Qt.WindowMinimized)
+
+    @Slot()
+    def on_btnRestore_clicked(self):
+        if self.btnMaximize.isEnabled() or self.btnRestore.isEnabled():
+            self.btnRestore.setVisible(False)
+            self.btnRestore.setEnabled(False)
+            self.btnMaximize.setVisible(True)
+            self.btnMaximize.setEnabled(True)
+
+        self.setWindowState(Qt.WindowNoState)
+
+    @Slot()
+    def on_btnMaximize_clicked(self):
+        if self.btnMaximize.isEnabled() or self.btnRestore.isEnabled():
+            self.btnRestore.setVisible(True)
+            self.btnRestore.setEnabled(True)
+            self.btnMaximize.setVisible(False)
+            self.btnMaximize.setEnabled(False)
+
+        self.setWindowState(Qt.WindowMaximized)
+
+    @Slot()
+    def on_btnClose_clicked(self):
+        self.close()
+
+    @Slot()
+    def on_titleBar_doubleClicked(self):
+        if not bool(self.windowState() & Qt.WindowMaximized):
+            self.on_btnMaximize_clicked()
+        else:
+            self.on_btnRestore_clicked()
+
+
+class ModernMessageBox(QMessageBox):
+    """ Modern message box.
+        Args:
+            parent (QWidget, optional): Parent widget.
+    """
+    def __init__(self, parent=None):
+        self._dialog = ModernDialog(parent=parent)
+        QMessageBox.__init__(self, self._dialog)
+
+        self.setupUi()
+
+    def setupUi(self):
+        self.setWindowFlags(Qt.Window | Qt.FramelessWindowHint | Qt.WindowSystemMenuHint)
+        self.setAttribute(Qt.WA_TranslucentBackground)
+
+        layout = QHBoxLayout()
+        layout.setSpacing(0)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self, alignment=Qt.AlignCenter)
+        self._dialog.windowContent.setLayout(layout)
+
+        self._dialog.show()
+
+    def hide(self):
+        QMessageBox.hide(self)
+        self._dialog.hide()


### PR DESCRIPTION
ModernDialog is used just like a QDialog.

```python
d = ModernDialog(hideWindowButtons=True)
d.setWindowTitle('Changelog')

main_layout = QVBoxLayout()
main_layout.setSpacing(10)

text = QTextEdit()
text.setPlainText('This is a text\nto demonstrate\na ModernDialog')
text.setReadOnly(True)
text.setFixedHeight(100)
main_layout.addWidget(text, alignment=Qt.AlignCenter)

button_box = QDialogButtonBox()
button_box.setOrientation(Qt.Horizontal)
button_box.setStandardButtons(QDialogButtonBox.Ok)
button_box.setCenterButtons(True)
button_box.accepted.connect(d.accept)
main_layout.addWidget(button_box, alignment=Qt.AlignCenter)

d.windowContent.setLayout(main_layout)
d.exec()
```
![grafik](https://user-images.githubusercontent.com/5948878/73978074-e1446a00-492b-11ea-85cc-6e481ffc0ba3.png)

ModernMessageBox is used just like a QMessageBox
Simple example below
```python
box = ModernMessageBox()
box.setIcon(QMessageBox.Question)
box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
box.setEscapeButton(QMessageBox.No)
box.setText("There is a new version available.\nWould you like to update now?")

if box.exec_() == QMessageBox.Yes:
    box.hide()
    print('yes')
else:
    print('no')
    box.hide()
```
![grafik](https://user-images.githubusercontent.com/5948878/73977561-e523bc80-492a-11ea-8b65-fa4c01c07ea3.png)
