### PR TITLE
Change the QScrollBar handle color so that it is visible again using newer PyQt versions

### DIFF
--- a/qtmodern/resources/style.qss
+++ b/qtmodern/resources/style.qss
@@ -56,14 +56,14 @@ QScrollBar:vertical {
 }
 
 QScrollBar::handle:vertical {
-  background-color: palette(alternate-base);
+  background-color: palette(midlight);
   border-radius: 2px;
   min-height: 20px;
   margin: 2px 4px 2px 4px;
 }
 
 QScrollBar::handle:vertical:hover, QScrollBar::handle:horizontal:hover, QScrollBar::handle:vertical:pressed, QScrollBar::handle:horizontal:pressed {
-  background-color:palette(midlight);
+  background-color:palette(highlight);
 }
 
 QScrollBar::add-line:vertical {
@@ -87,7 +87,7 @@ QScrollBar:horizontal{
 }
 
 QScrollBar::handle:horizontal {
-  background-color: palette(alternate-base);
+  background-color: palette(midlight);
   border-radius: 2px;
   min-width: 20px;
   margin: 4px 2px 4px 2px;


### PR DESCRIPTION
QScrollBar before changes:
![before](https://user-images.githubusercontent.com/48512334/79851599-d5623300-83c5-11ea-9e52-22cca4840d39.gif)

and with changes:
![after](https://user-images.githubusercontent.com/48512334/79851602-d6936000-83c5-11ea-9131-a0d63f7377da.gif)


Running on Windows 10 Home build 18363.720 using:

PyCharm version: 2019.3.4 (Professional Edition)
Anaconda vesion: 2020.02
Python version: 3.7.7
PyQt version: 5.14.1