### PR TITLE
Change the behavior of dragging title bar when the window is maximized.

### DIFF
--- a/qtmodern/windows.py
+++ b/qtmodern/windows.py
@@ -1,4 +1,4 @@
-from qtpy.QtCore import Qt, QMetaObject, Signal, Slot
+from qtpy.QtCore import Qt, QMetaObject, Signal, Slot, QPoint
 from qtpy.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QToolButton,
                             QLabel, QSizePolicy)
 from ._utils import QT_VERSION, PLATFORM, resource_path
@@ -31,6 +31,16 @@ class WindowDragger(QWidget):
 
     def mouseMoveEvent(self, event):
         if self._mousePressed:
+            if self._window.windowState() == Qt.WindowMaximized:
+                # restore the window firstly
+                self._window.on_btnRestore_clicked()
+                # move the window back on the mouse
+                self._window.move(self._mousePos - QPoint(
+                    0.5 * self.geometry().width(),
+                    0.5 * self.geometry().height(),
+                ))
+                # refresh _windowPos
+                self._windowPos = self._window.pos()
             self._window.move(self._windowPos +
                               (event.globalPos() - self._mousePos))
 


### PR DESCRIPTION
The maximized window supposes to restore first and then follow the mouse while the title bar is dragged. But in qtmodern, the window will move with mouse directly and cause some bugs.  I add some code in mouseMoveEvent() and it seam to be running well, so please have a check about it. 😄 

By the way, I'm a novice in Qt and working on my graduation project. As a good example, this project help me a lot in learning QT. Thanks a lot! And this is my first time using pull request and if I do something wrong, please feel free to let me know.

